### PR TITLE
Create example of aggregation with collection() function

### DIFF
--- a/testing_xslt_transform/aggregate-counts.xhtml
+++ b/testing_xslt_transform/aggregate-counts.xhtml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <title>Aggregated counts</title>
+      <style type="text/css">
+          table,
+          tr,
+          th,
+          td {
+            border: 1px solid black;
+            border-collapse: collapse;
+          }
+          th,
+          td {
+            padding: 2px 3px;
+          }
+          tr:not(:first-child) &gt; th {
+            text-align: left;
+          }
+          td {
+            text-align: right;
+          }</style>
+   </head>
+   <body>
+      <h1>Aggregated counts</h1>
+      <table>
+         <tr>
+            <th>Language</th>
+            <th>Count</th>
+            <th>Percentage</th>
+         </tr>
+         <tr>
+            <th></th>
+            <td>55</td>
+            <td>4.41</td>
+         </tr>
+         <tr>
+            <th>Germanic</th>
+            <td>1</td>
+            <td>0.08</td>
+         </tr>
+         <tr>
+            <th>Greek</th>
+            <td>8</td>
+            <td>0.64</td>
+         </tr>
+         <tr>
+            <th>Hungarian</th>
+            <td>3</td>
+            <td>0.24</td>
+         </tr>
+         <tr>
+            <th>Italian</th>
+            <td>1</td>
+            <td>0.08</td>
+         </tr>
+         <tr>
+            <th>Latin</th>
+            <td>9</td>
+            <td>0.72</td>
+         </tr>
+         <tr>
+            <th>N/a</th>
+            <td>23</td>
+            <td>1.84</td>
+         </tr>
+         <tr>
+            <th>N/q</th>
+            <td>1</td>
+            <td>0.08</td>
+         </tr>
+         <tr>
+            <th>Slavic</th>
+            <td>1052</td>
+            <td>84.29</td>
+         </tr>
+         <tr>
+            <th>Turkic</th>
+            <td>95</td>
+            <td>7.61</td>
+         </tr>
+      </table>
+   </body>
+</html>

--- a/testing_xslt_transform/aggregate-counts.xsl
+++ b/testing_xslt_transform/aggregate-counts.xsl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:cam="sevdah-functions"
+  xmlns="http://www.w3.org/1999/xhtml" exclude-result-prefixes="#all" version="3.0">
+  <xsl:output method="xhtml" html-version="5" omit-xml-declaration="no" include-content-type="no"
+    indent="yes"/>
+  <!-- ================================================================== -->
+  <!-- Stylesheet variables                                               -->
+  <!-- ================================================================== -->
+  <xsl:variable name="all-docs" as="document-node()+"
+    select="collection('../texts_xml/?select=*.xml')"/>
+  <xsl:variable name="all-lang-instances" as="xs:string+" select="$all-docs//origin/@lang"/>
+  <xsl:variable name="all-lang-names" as="xs:string+"
+    select="$all-lang-instances => distinct-values() => sort()"/>
+  <xsl:variable name="total-lang-instance-count" as="xs:integer" select="count($all-lang-instances)"/>
+  <!-- ================================================================== -->
+  <!-- Functions                                                          -->
+  <!-- ================================================================== -->
+  <xsl:function name="cam:initial-cap" as="xs:string">
+    <xsl:param name="input" as="xs:string"/>
+    <xsl:value-of select="substring($input, 1, 1) ! upper-case(.) || substring($input, 2)"/>
+  </xsl:function>
+  <!-- ================================================================== -->
+  <!-- Templates                                                          -->
+  <!-- ================================================================== -->
+  <xsl:template name="xsl:initial-template">
+    <html>
+      <head>
+        <title>Aggregated counts</title>
+        <style type="text/css">
+          table,
+          tr,
+          th,
+          td {
+            border: 1px solid black;
+            border-collapse: collapse;
+          }
+          th,
+          td {
+            padding: 2px 3px;
+          }
+          tr:not(:first-child) > th {
+            text-align: left;
+          }
+          td {
+            text-align: right;
+          }</style>
+      </head>
+      <body>
+        <h1>Aggregated counts</h1>
+        <table>
+          <tr>
+            <th>Language</th>
+            <th>Count</th>
+            <th>Percentage</th>
+          </tr>
+          <xsl:for-each select="$all-lang-names">
+            <xsl:variable name="lang-instance-count" as="xs:integer"
+              select="count($all-lang-instances[. eq current()])"/>
+            <tr>
+              <th>
+                <xsl:value-of select="cam:initial-cap(.)"/>
+              </th>
+              <td>
+                <xsl:value-of select="$lang-instance-count"/>
+              </td>
+              <td>
+                <xsl:value-of
+                  select="(100 * $lang-instance-count div $total-lang-instance-count) => round(2)"/>
+              </td>
+            </tr>
+          </xsl:for-each>
+        </table>
+      </body>
+    </html>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
*testing_xslt_transform/aggregate-counts.xsl* creates *testing_xslt_transform/aggregate-counts.xhtml*. Note that when operating over a collection, the main template has a `@name` attribute instead of a `@match` attribute. When running the transformation inside \<oXygen/\>, set the dropdown for the XML intput file to `( None )`. For information about the syntax of the `collection()` function see https://www.saxonica.com/documentation12/index.html#!functions/fn/collection and the link there, labeled "Collections".